### PR TITLE
Save files instead of json strings

### DIFF
--- a/lib/transifex-api.js
+++ b/lib/transifex-api.js
@@ -81,8 +81,16 @@ Api.prototype.prepareRequests = function(availableResources, callback) {
           return;
         }
 
+        var uri = "";
+
+        if( self.options.mode === "file" ){
+          uri = ["project", self.options.project, "resource", slug, "translation", code].join('/').concat('?file=true');
+        } else {
+          uri = ["project", self.options.project, "resource", slug, "translation", code, "strings"].join('/');
+        }
+
         requests.push( {
-          uri: ["project", self.options.project, "resource", slug, "translation", code, "strings"].join('/'),
+          uri: uri,
           slug: slug,
           code: code,
           isSource: code === availableResources[slug].source
@@ -128,7 +136,13 @@ Api.prototype.writeLanguageFiles = function(strings, callback) {
 
     // write file
     // discard keys with empty translations
-    var transformed = self.options.templateFn(s.strings.filter(function(s) { return s.translation !== ""; }));
+    var transformed = '';
+    if( self.options.mode === "file" ){
+      transformed = s.strings;
+    } else {
+      transformed = self.options.templateFn(s.strings.filter(function(s) { return s.translation !== ""; }));
+    }
+
     grunt.file.write(filepath, transformed);
     grunt.log.ok("Successfully downloaded", s.slug, "|", s.code, "strings into", filepath);
   });

--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "async": "~0.2.9",
-    "request": "~2.27.0",
-    "grunt": "~0.4.2",
-    "inquirer": "~0.3.5",
-    "underscore": "~1.5.2"
+    "async": "~0.8.0",
+    "request": "~2.34.0",
+    "grunt": "~0.4.4",
+    "inquirer": "~0.4.1",
+    "underscore": "~1.6.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.2"
+    "grunt": "~0.4.4"
   }
 }

--- a/tasks/transifex.js
+++ b/tasks/transifex.js
@@ -15,6 +15,7 @@ module.exports = function(grunt) {
       endpoint : 'http://www.transifex.com/api/2',
       project  : this.target,
       reviewed : this.flags.reviewed,
+      mode: "json",
       filename : "_resource_/_lang_.json",
       templateFn: function(strings) { return JSON.stringify(_.object(_.pluck(strings, "key"), _.pluck(strings, "translation"))); }
     });


### PR DESCRIPTION
Related to issue #2, I've been hacking around with this:

According to [transifex docu](http://docs.transifex.com/developer/api/translations), you can add a get parameter of `?file` to the URL and it will download the file itself.

So I added a `mode` option that when set to "file" will skip the json string parsing and just save the retrieved contents as whatever filename I've specified in the `filename` option.

```
        // get transifex translations
        transifex: {
            "radio-buttons-for-taxonomies": {
                options: {
                    targetDir: "languages",     
                    mode: "file",
                    filename : "_resource_-_lang_.po",
                }
            }
        }
```
