### PR TITLE
Make discarding empty strings optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Provides a Grunt task that downloads translation strings from Transifex into you
           resources: ["localizable_enstrings"],
           languages: ["en_US", "fr"],
           filename : "_resource_-_lang_.json",
+          filterEmpty: true,                            // defaults to true (remove empty strings). Set to false to keep them.
           templateFn: function(strings) { return ...; }  // customize the output file format (see below)
         }
       },
@@ -37,7 +38,7 @@ This configuration enables running the `transifex` Grunt task on the command lin
         'en_US' and 'fr'
    grunt transifex:ios-ready:reviewed
      --> Same as above, but downloads reviewed strings only
-  
+
    grunt transifex
      --> Downloads reviewed & non-reviewed strings for all configured Transifex projects
    grunt transifex::reviewed
@@ -56,7 +57,7 @@ Translated strings will saved into plain JSON if you use the default output conf
 ## Transifex credentials
 
 When the plugin runs for the first time, it will prompt the user for a Transifex username and password.
-It will store this information in a `.transifexrc` file created in the current directory. 
+It will store this information in a `.transifexrc` file created in the current directory.
 
 On subsequent executions, the user won't be prompted again. Transifex credentials will be read from `.transifexrc`
 

--- a/lib/transifex-api.js
+++ b/lib/transifex-api.js
@@ -140,7 +140,7 @@ Api.prototype.writeLanguageFiles = function(strings, callback) {
     if( self.options.mode === "file" ){
       transformed = s.strings;
     } else {
-      transformed = self.options.templateFn(s.strings.filter(function(s) { return s.translation !== ""; }));
+      transformed = self.options.templateFn(s.strings.filter(function(s) { return !self.options.filterEmpty || s.translation !== ""; }));
     }
 
     grunt.file.write(filepath, transformed);

--- a/tasks/transifex.js
+++ b/tasks/transifex.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
       reviewed : this.flags.reviewed,
       mode: "json",
       filename : "_resource_/_lang_.json",
-      templateFn: function(strings) { return JSON.stringify(_.object(_.pluck(strings, "key"), _.pluck(strings, "translation"))); }
+      templateFn: function(strings) { return JSON.stringify(_.object(_.pluck(strings, "key"), _.pluck(strings, "translation"))); },
+      filterEmpty:true
     });
 
     /** Attempt to create target directory


### PR DESCRIPTION
This adds a new `option`, called `discardEmpty`, that when set to `false` will keep empty translations. The current behavior is it always discards empty strings. It also defaults to `true`, in order to keep old functionality the same.
